### PR TITLE
Require older numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "jsoncomment",
-        "numpy",
+        "numpy<2",
         "scipy",
         "matplotlib",
         "seaborn",


### PR DESCRIPTION
Avoids a dependency conflict between statannotations and pandas.